### PR TITLE
disable shm usage by default

### DIFF
--- a/cdipy/chrome.py
+++ b/cdipy/chrome.py
@@ -40,6 +40,8 @@ CHROME_PARAMS = [
     "--hide-scrollbars",
     "--mute-audio",
 ]
+if not os.environ.get("CDIPY_USE_SHM"):
+    CHROME_PARAMS.append("--disable-dev-shm-usage")
 
 WS_RE = re.compile(r"listening on (ws://[^ ]*)")
 


### PR DESCRIPTION
docker containers dont get much shared memory by default so this prevents unexpected chrome crashes